### PR TITLE
adicionando crossOrigin para conseguir liberar para o frontend consumir.

### DIFF
--- a/src/main/kotlin/com/cmach/todoapikotlin/controllers/HelloController.kt
+++ b/src/main/kotlin/com/cmach/todoapikotlin/controllers/HelloController.kt
@@ -1,12 +1,14 @@
 package com.cmach.todoapikotlin.controllers
 
 import com.cmach.todoapikotlin.model.Hello
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.concurrent.atomic.AtomicLong
 
 @RestController
+@CrossOrigin(origins = ["http://localhost:5173/"])
 class HelloController {
 
     @RequestMapping("/hello")


### PR DESCRIPTION
sem atribuir no backend o cross origin não é possivel o frontend consumir a api.